### PR TITLE
Fix Admin url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,5 +38,5 @@ help:
 	# Nebuleuse
 	#
 	# Nebuleuse API:    http://0.0.0.0:12080/
-	# Nebuleuse Admin:  http://0.0.0.0:12080/admin/dist/ (user: test / pass: test)
+	# Nebuleuse Admin:  http://0.0.0.0:12080/admin/ (user: test / pass: test)
 	#


### PR DESCRIPTION
After reinstalling from scratch, I found that the Admin url was not the one I set in Makefile help.